### PR TITLE
chore: only lint go project files in github actions

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -38,5 +38,4 @@ jobs:
         with:
           version: v1.55.2
           working-directory: ./go
-          only-new-issues: true
-          args: --timeout=5m
+          args: --timeout=5m --path-prefix=./go


### PR DESCRIPTION
This PR addresses a [GitHub Actions failure](https://github.com/radiustechsystems/sdk/actions/runs/13595276965) caused by `golangci-lint` being run without specifying a `--path-prefix`, which checks standard library code inside the Go installation instead of just checking our SDK project files.