### PR TITLE
chore: use correct version and config for golangci-lint action

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -21,21 +21,12 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./go
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
-          cache: true
-
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
-          working-directory: ./go
-          args: --timeout=5m --path-prefix=./go
+          version: v1.64


### PR DESCRIPTION
This PR addresses a [GitHub Actions failure](https://github.com/radiustechsystems/sdk/actions/runs/13596650115/job/38014960240) caused by misconfiguration of golangci/golangci-lint-action@v6 and use of an older version.