### PR TITLE
chore: use correct version and config for golangci-lint action

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -23,10 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.23.x'
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64
+          working-directory: go


### PR DESCRIPTION
This PR addresses a [GitHub Action failure](https://github.com/radiustechsystems/sdk/actions/runs/13596933875/job/38015796221) caused by a missing `working-directory` field.