### PR TITLE
chore: fix typescript-publish action

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -58,9 +58,14 @@ jobs:
       - name: Build package
         working-directory: typescript
         run: pnpm build:prod
-      
+
       - name: Publish to NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
         working-directory: typescript
-        run: npm publish --provenance
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR fixes the `typescript-publish` GitHub Action, following the instructions found here: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages