### PR TITLE
docs: fix and improve code examples in go + typescript sdks

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Radius TypeScript SDK will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Type exports for `BigNumberish`, `BytesLike`, and `HttpClient`, required for custom `Signer` implementations
+
+### Security
+- Added pnpm override for `esbuild` requiring v0.25.0 or above, to address a known security vulnerability
+
 ## 1.0.0
 ### Added
 - Initial SDK implementation

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -92,9 +92,9 @@ console.log('Stored value:', result[0]);
 ### Custom Transaction Signing
 
 ```typescript
-import { Address, BigNumberish, BytesLike, Hash, SignedTransaction, Transaction } from '@radiustechsystems/sdk';
+import { Address, BigNumberish, BytesLike, Hash, SignedTransaction, Signer, Transaction } from '@radiustechsystems/sdk';
 
-class MyCustomSigner {
+class MyCustomSigner implements Signer {
     address(): Address { /* ... */ }
     chainID(): BigNumberish { /* ... */ }
     hash(transaction: Transaction): Hash { /* ... */ }

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -14,7 +14,6 @@ way to interact with the Radius platform.
 ## Requirements
 
 - Node.js >= 20.12.2
-- npm, yarn, or pnpm
 
 ## Installation
 
@@ -62,7 +61,7 @@ console.log('Transaction hash:', receipt.txHash.hex());
 import { ABIFromJSON, BytecodeFromHex } from '@radiustechsystems/sdk';
 
 // Parse ABI and bytecode
-const abi = new ABIFromJSON(`[{"inputs":[],"name":"get","outputs":[{"type":"uint256"}],"type":"function"},{"inputs":[{"type":"uint256"}],"name":"set","type":"function"}]`);
+const abi = ABIFromJSON(`[{"inputs":[],"name":"get","outputs":[{"type":"uint256"}],"type":"function"},{"inputs":[{"type":"uint256"}],"name":"set","type":"function"}]`);
 const bytecode = BytecodeFromHex('608060405234801561001057600080fd5b50610150806100...');
 
 // Deploy the contract
@@ -76,7 +75,7 @@ import { NewContract, AddressFromHex, ABIFromJSON } from '@radiustechsystems/sdk
 
 // Reference an existing contract
 const address = AddressFromHex('0x...');
-const abi = new ABIFromJSON(`[{"inputs":[],"name":"get","outputs":[{"type":"uint256"}],"type":"function"},{"inputs":[{"type":"uint256"}],"name":"set","type":"function"}]`);
+const abi = ABIFromJSON(`[{"inputs":[],"name":"get","outputs":[{"type":"uint256"}],"type":"function"},{"inputs":[{"type":"uint256"}],"name":"set","type":"function"}]`);
 const contract = NewContract(address, abi);
 
 // Write to the contract
@@ -93,16 +92,18 @@ console.log('Stored value:', result[0]);
 ### Custom Transaction Signing
 
 ```typescript
-import { NewClefSigner, NewAccount, withSigner, AddressFromHex } from '@radiustechsystems/sdk';
+import { Address, BigNumberish, BytesLike, Hash, SignedTransaction, Transaction } from '@radiustechsystems/sdk';
 
-// Use an external signer (e.g., Clef)
-const address = AddressFromHex('0x...');
-const clefSigner = NewClefSigner(address, client, 'http://localhost:8550');
-const account = await NewAccount(withSigner(clefSigner));
-
-// Or create a custom signer
-const customSigner = new MyCustomSigner();
-const customSignerAccount = NewAccount(withSigner(customSigner));
+class MyCustomSigner {
+    address(): Address { /* ... */ }
+    chainID(): BigNumberish { /* ... */ }
+    hash(transaction: Transaction): Hash { /* ... */ }
+    signMessage(message: BytesLike): Promise<Uint8Array> { /* ... */ }
+    signTransaction(transaction: Transaction): Promise<SignedTransaction> { /* ... */ }
+    constructor(...args) { /* ... */ }
+}
+const signer = new MyCustomSigner(...args);
+const account = NewAccount(withSigner(signer));
 ```
 
 ### Logging and Request Interceptors
@@ -115,7 +116,7 @@ const client = await NewClient('https://your-radius-endpoint',
         console.log(message, data);
     }),
     withInterceptor(async (reqBody, response) => {
-        // Process or log responses
+        // Examine request body, modify response, etc.
         return response;
     })
 );
@@ -127,7 +128,9 @@ const client = await NewClient('https://your-radius-endpoint',
 import { NewClient, withHttpClient } from '@radiustechsystems/sdk';
 
 const client = await NewClient('https://your-radius-endpoint',
-    withHttpClient(customHttpClient)
+    withHttpClient(async (url: string | URL | Request, init?: RequestInit | undefined): Promise<Response> => {
+        // Make a custom HTTP request, or use a library like axios
+    })
 );
 ```
 

--- a/typescript/radius/sdk.ts
+++ b/typescript/radius/sdk.ts
@@ -1,19 +1,11 @@
 import { Account } from '../src/accounts';
 import type { AccountOption } from '../src/accounts';
 import { withPrivateKey, withSigner } from '../src/accounts';
-import { ClefSigner } from '../src/auth';
-import { PrivateKeySigner } from '../src/auth';
-import type { Signer, SignerClient } from '../src/auth';
-import { Client } from '../src/client';
-import type { ClientOption } from '../src/client';
+import { ClefSigner, PrivateKeySigner, Signer, SignerClient } from '../src/auth';
+import { Client, ClientOption } from '../src/client';
 import { withHttpClient, withInterceptor, withLogger } from '../src/client';
-import { ABI } from '../src/common';
-import { Address } from '../src/common';
-import { Event } from '../src/common';
-import { Hash } from '../src/common';
-import { Receipt } from '../src/common';
+import { ABI, Address, Event, Hash, HttpClient, Receipt, Transaction } from '../src/common';
 import type { SignedTransaction } from '../src/common';
-import { Transaction } from '../src/common';
 import {
   abiFromJSON as ABIFromJSON,
   addressFromHex as AddressFromHex,
@@ -22,6 +14,7 @@ import {
   zeroAddress,
 } from '../src/common';
 import { Contract } from '../src/contracts';
+import type { BigNumberish, BytesLike } from '../src/providers/eth';
 import type { Interceptor, Logf } from '../src/transport';
 
 // Re-export classes
@@ -40,7 +33,16 @@ export {
 };
 
 // Re-export types
-export type { Interceptor, Logf, Signer, SignerClient, SignedTransaction };
+export type {
+  BigNumberish,
+  BytesLike,
+  HttpClient,
+  Interceptor,
+  Logf,
+  Signer,
+  SignerClient,
+  SignedTransaction,
+};
 
 // Re-export functions
 export {


### PR DESCRIPTION
This PR corrects some mistakes in the code examples that appear in the `README.md` files, for both the Go and TypeScript SDKs.

This PR also also adds exports for the `BigNumberish`, `BytesLike`, and `HttpClient` types to the TypeScript SDK public interface, which are needed when implementing a custom `Signer`.